### PR TITLE
Add missing base64 import to handshake client

### DIFF
--- a/encrypted_chat/encrypted_chat_client_with_handshake.py
+++ b/encrypted_chat/encrypted_chat_client_with_handshake.py
@@ -1,5 +1,6 @@
 import socket
 import os
+import base64
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.asymmetric import dh
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF


### PR DESCRIPTION
## Summary
- fix missing base64 import in handshake client so session key encoding works

## Testing
- `python -m py_compile encrypted_chat/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba7a272ecc832b95275853cb750de6