### PR TITLE
Add read receipts and CLI usage guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+venv/
+
+# PyInstaller artifacts
+build/
+dist/
+*.spec
+
+# Inno Setup artifacts
+installer.iss
+EncryptedChatClientSetup.exe
+is.exe

--- a/CLI_USAGE.md
+++ b/CLI_USAGE.md
@@ -1,0 +1,15 @@
+# 命令提示符使用手册
+
+该手册介绍如何在命令提示符（CLI）下运行加密聊天客户端以及常用命令。
+
+## 启动
+1. 启动服务器：`python encrypted_chat/encrypted_chat_server.py`
+2. 在另一终端运行客户端：`python encrypted_chat/encrypted_chat_client.py`
+
+## 常用命令
+- 直接输入文本并回车即可向对方发送消息。
+- `/file <路径>`：发送指定文件，双方都会看到进度条。
+- `/recall <消息ID>`：撤回之前发送的消息，消息 ID 会在发送时显示。
+- `/exit`：退出客户端。
+
+客户端界面使用颜色区分双方消息，并在对方读取消息后显示提示。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Encrypted Chat Client
+
+## 项目简介
+该项目展示了如何使用 Python 的 `socket` 与 `cryptography` 库构建一个简易的端到端加密聊天工具。服务器启动后会生成对称密钥并负责转发消息，客户端通过密钥对消息进行加解密，实现安全通信。
+
+## 应用场景
+- 局域网或内网中的临时安全聊天
+- 学习对称加密与网络编程的示例
+- 快速演示加密通信流程
+
+## 项目优势
+- **安全性**：使用 `Fernet` 算法，对消息内容进行可靠加密
+- **易上手**：服务器与客户端脚本简单，适合学习与定制
+- **可扩展**：提供 Windows 打包脚本，支持一键构建安装程序
+- **实时性**：自动显示连接延迟并支持大文件传输进度
+- **消息回执与撤回**：提供已读提示并支持发送方撤回消息，命令行界面以颜色区分双方消息
+
+## 系统兼容性
+- 支持 Windows 7、8、10、11
+- 兼容 Python 3.8 至 3.12，`setup_env.ps1` 可通过 `-PythonVersion` 参数指定所需版本
+
+## 界面优化
+图形化客户端现在提供滚动聊天记录与 Enter 快捷发送消息，更便于使用
+
+## 快速开始
+### 运行源代码
+1. 安装依赖：`pip install -r requirements.txt`
+2. 启动服务器：`python encrypted_chat/encrypted_chat_server.py`
+3. 在另一终端启动客户端：`python encrypted_chat/encrypted_chat_client.py`
+4. 输入消息即可通信；使用 `/file <路径>` 发送文件，终端会显示发送与接收进度
+5. 需要撤回消息时使用 `/recall <消息ID>`，消息 ID 会在发送时显示
+6. 客户端每隔数秒会显示与服务器之间的实时延迟，使用 `/exit` 退出
+7. 更多命令详见 [CLI_USAGE.md](CLI_USAGE.md)
+
+### 构建 Windows 安装包
+项目提供 `build_windows_installer.py` 与 `setup_env.ps1` 用于自动构建 Windows 安装程序，详细步骤见 [WINDOWS_INSTALLER.md](WINDOWS_INSTALLER.md)。
+安装完成后，可在开始菜单找到两种启动方式：
+- **Encrypted Chat Client (CLI)**：命令提示符模式
+- **Encrypted Chat Client (GUI)**：窗口界面模式
+

--- a/WINDOWS_INSTALLER.md
+++ b/WINDOWS_INSTALLER.md
@@ -1,0 +1,28 @@
+# Windows Installer Guide
+
+To package the encrypted chat client for Windows, run the provided setup script.
+It checks for a Python environment, installs missing components (using winget or
+Chocolatey when available), and then builds the installer. Missing Python
+dependencies and PyInstaller are fetched automatically before the build starts.
+The script supports Windows 7, 8, 10, and 11, and works with Python versions
+3.8 through 3.12.
+
+## Steps
+1. Clone or download this repository and open **PowerShell** in its directory.
+2. Run the setup script (optionally specify a Python version):
+
+   ```powershell
+   .\setup_env.ps1 -PythonVersion 3.11
+   ```
+
+   The script ensures the requested Python version is installed (falling back to
+   the latest if omitted), installs project dependencies, generates a standalone
+   executable, and packages it into an installer.
+
+The process produces `EncryptedChatClientSetup.exe`, which guides users through
+selecting an install directory and installs the `encrypted_chat_client.exe`
+and `encrypted_chat_client_gui.exe` binaries.
+
+After installation, two shortcuts are added to the Start Menu:
+- **Encrypted Chat Client (CLI)** 打开命令提示符界面
+- **Encrypted Chat Client (GUI)** 打开窗口界面

--- a/build_windows_installer.py
+++ b/build_windows_installer.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Automation script to build the Windows executable and installer."""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import urllib.request
+
+ROOT = Path(__file__).resolve().parent
+DIST_DIR = ROOT / "dist"
+
+
+def check_environment() -> None:
+    """Ensure the script is running on a supported platform."""
+    if platform.system() != "Windows":
+        raise RuntimeError("Windows build script must be run on a Windows host")
+
+    win_version = platform.release()
+    print(f"Detected Windows version: {win_version}")
+
+    if sys.version_info < (3, 8):
+        raise RuntimeError("Python 3.8 or newer is required to build the installer")
+    print(f"Using Python {platform.python_version()}")
+
+
+def run(cmd: list[str]) -> None:
+    """Run a command and raise with context if it fails."""
+    print("Running:", " ".join(cmd))
+    completed = subprocess.run(cmd, capture_output=True, text=True)
+    if completed.stdout:
+        print(completed.stdout)
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr)
+    if completed.returncode != 0:
+        raise subprocess.CalledProcessError(completed.returncode, cmd)
+
+
+def ensure_requirements() -> None:
+    """Install missing project requirements and PyInstaller."""
+    req_file = ROOT / "requirements.txt"
+    to_install: list[str] = []
+
+    if req_file.exists():
+        for line in req_file.read_text().splitlines():
+            pkg = line.strip()
+            if not pkg or pkg.startswith("#"):
+                continue
+            module = re.split(r"[<>=]", pkg, 1)[0]
+            if importlib.util.find_spec(module) is None:
+                to_install.append(pkg)
+
+    if shutil.which("pyinstaller") is None:
+        to_install.append("pyinstaller")
+
+    if to_install:
+        print("Installing Python requirements and PyInstaller...")
+        run([sys.executable, "-m", "pip", "install", *to_install])
+    else:
+        print("All required Python packages are already installed.")
+
+
+def clean_artifacts() -> None:
+    """Remove old build artifacts to avoid conflicts."""
+    if DIST_DIR.exists():
+        shutil.rmtree(DIST_DIR)
+    iss = ROOT / "installer.iss"
+    if iss.exists():
+        iss.unlink()
+
+
+def ensure_iscc() -> None:
+    """Ensure the Inno Setup compiler is available."""
+    if shutil.which('iscc') is not None:
+        return
+
+    if sys.platform != 'win32':
+        raise RuntimeError(
+            'iscc (Inno Setup compiler) not found and automatic installation is only supported on Windows.',
+        )
+
+    url = 'https://jrsoftware.org/download.php/is.exe'
+    installer = ROOT / 'is.exe'
+    print('Downloading Inno Setup...')
+    urllib.request.urlretrieve(url, installer)
+    print('Installing Inno Setup...')
+    run([str(installer), '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART'])
+    installer.unlink(missing_ok=True)
+    if shutil.which('iscc') is None:
+        raise RuntimeError(
+            'iscc (Inno Setup compiler) not found after installation. Please ensure it is on PATH.',
+        )
+
+def build_executable() -> None:
+    """Build both console and GUI executables using PyInstaller."""
+    run(
+        [
+            "pyinstaller",
+            "--onefile",
+            str(ROOT / "encrypted_chat" / "encrypted_chat_client.py"),
+        ]
+    )
+    run(
+        [
+            "pyinstaller",
+            "--onefile",
+            "--windowed",
+            str(ROOT / "encrypted_chat" / "encrypted_chat_client_gui.py"),
+        ]
+    )
+
+
+def create_inno_script() -> Path:
+    """Create the Inno Setup script for packaging."""
+    iss_path = ROOT / "installer.iss"
+    iss_content = f"""
+[Setup]
+AppName=Encrypted Chat Client
+AppVersion=1.0
+DefaultDirName={{autopf}}\\EncryptedChatClient
+OutputBaseFilename=EncryptedChatClientSetup
+
+[Files]
+Source: "{DIST_DIR}\\encrypted_chat_client.exe"; DestDir: "{{app}}"; Flags: ignoreversion
+Source: "{DIST_DIR}\\encrypted_chat_client_gui.exe"; DestDir: "{{app}}"; Flags: ignoreversion
+
+[Icons]
+Name: "{{autoprograms}}\\Encrypted Chat Client (CLI)"; Filename: "{{app}}\\encrypted_chat_client.exe"
+Name: "{{autoprograms}}\\Encrypted Chat Client (GUI)"; Filename: "{{app}}\\encrypted_chat_client_gui.exe"
+""".strip()
+    iss_path.write_text(iss_content)
+    return iss_path
+
+
+def build_installer(iss_path: Path) -> None:
+    """Compile the Inno Setup script."""
+    run(["iscc", str(iss_path)])
+    iss_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    check_environment()
+    clean_artifacts()
+    ensure_requirements()
+    ensure_iscc()
+    build_executable()
+    iss = create_inno_script()
+    build_installer(iss)
+    print("Installer built: EncryptedChatClientSetup.exe")

--- a/encrypted_chat/encrypted_chat_client.py
+++ b/encrypted_chat/encrypted_chat_client.py
@@ -1,46 +1,214 @@
+"""Encrypted chat client with file transfer, latency display and easier CLI.
+
+This script provides a command-line client capable of:
+* sending and receiving text messages with length-prefixed framing for
+  smoother encode/decode handling;
+* measuring round-trip latency to the server in real time;
+* transferring large files with progress feedback;
+* showing read receipts for sent messages; and
+* allowing senders to recall previously sent messages; and
+* colorized output with simple commands (``/file``, ``/recall`` and ``/exit``)
+  to reduce operational difficulty.
+"""
+
+from __future__ import annotations
+
+import argparse
 import socket
+import struct
+import threading
+import time
+from pathlib import Path
+
 from cryptography.fernet import Fernet
+from colorama import Fore, Style, init
 
-def load_key():
-    # 从文件加载加密密钥
-    with open("key.key", "rb") as key_file:
-        return key_file.read()
 
-def main():
+BUFFER_SIZE = 4096
+
+
+def load_key() -> bytes:
+    """Load or create the symmetric encryption key."""
+    key_path = Path("key.key")
+    if not key_path.exists():
+        key_path.write_bytes(Fernet.generate_key())
+    return key_path.read_bytes()
+
+
+def send_encrypted(sock: socket.socket, cipher: Fernet, data: bytes) -> None:
+    encrypted = cipher.encrypt(data)
+    sock.sendall(struct.pack("!I", len(encrypted)))
+    sock.sendall(encrypted)
+
+
+def recv_encrypted(sock: socket.socket, cipher: Fernet) -> bytes:
+    header = sock.recv(4)
+    if len(header) < 4:
+        raise ConnectionError("connection closed")
+    (size,) = struct.unpack("!I", header)
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise ConnectionError("connection closed")
+        data += chunk
+    return cipher.decrypt(data)
+
+
+def send_text(sock: socket.socket, cipher: Fernet, text: str) -> None:
+    send_encrypted(sock, cipher, text.encode())
+
+
+def send_file(sock: socket.socket, cipher: Fernet, path: Path) -> None:
+    filesize = path.stat().st_size
+    send_text(sock, cipher, f"FILE|{path.name}|{filesize}")
+    sent = 0
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(BUFFER_SIZE)
+            if not chunk:
+                break
+            send_encrypted(sock, cipher, chunk)
+            sent += len(chunk)
+            progress = sent / filesize * 100
+            print(f"Sending {path.name}: {progress:.1f}%", end="\r")
+    print(f"Sending {path.name}: 100%        ")
+
+
+def handle_receive(
+    sock: socket.socket,
+    cipher: Fernet,
+    stop_event: threading.Event,
+    pending_reads: set[int],
+    received_messages: dict[int, str],
+) -> None:
+    pending_file: dict[str, tuple[Path, int, int]] | None = None
+    while not stop_event.is_set():
+        try:
+            data = recv_encrypted(sock, cipher)
+        except Exception:
+            print("Connection closed by server.")
+            stop_event.set()
+            break
+
+        text = data.decode(errors="ignore")
+        if text.startswith("PONG|"):
+            ts = float(text.split("|", 1)[1])
+            latency = (time.time() - ts) * 1000
+            print(Fore.MAGENTA + f"Latency: {latency:.0f} ms")
+        elif text.startswith("READ|"):
+            msg_id = int(text.split("|", 1)[1])
+            if msg_id in pending_reads:
+                pending_reads.remove(msg_id)
+                print(Fore.YELLOW + f"Peer read message {msg_id}")
+        elif text.startswith("FILE|"):
+            _, filename, size = text.split("|", 2)
+            pending_file = (Path(filename), int(size), 0)
+            print(Fore.CYAN + f"Receiving {filename} ({size} bytes)")
+            with pending_file[0].open("wb"):
+                pass  # touch file
+        elif pending_file:
+            file_path, total, received = pending_file
+            with file_path.open("ab") as f:
+                f.write(data)
+            received += len(data)
+            progress = received / total * 100
+            print(
+                Fore.CYAN
+                + f"Receiving {file_path.name}: {progress:.1f}%"
+                + Style.RESET_ALL,
+                end="\r",
+            )
+            if received >= total:
+                print(Fore.CYAN + f"Receiving {file_path.name}: 100%        ")
+                pending_file = None
+            else:
+                pending_file = (file_path, total, received)
+        elif text.startswith("RECALL|"):
+            msg_id = int(text.split("|", 1)[1])
+            received_messages.pop(msg_id, None)
+            print(Fore.CYAN + f"Peer recalled message {msg_id}")
+        elif text.startswith("MSG|"):
+            _, msg_id_str, content = text.split("|", 2)
+            msg_id = int(msg_id_str)
+            received_messages[msg_id] = content
+            print(Fore.CYAN + f"Peer({msg_id_str}): {content}")
+            send_text(sock, cipher, f"READ|{msg_id_str}")
+        else:
+            print(Fore.CYAN + f"{text}")
+
+
+def ping_loop(sock: socket.socket, cipher: Fernet, stop_event: threading.Event) -> None:
+    while not stop_event.is_set():
+        ts = str(time.time())
+        send_text(sock, cipher, f"PING|{ts}")
+        stop_event.wait(5)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Encrypted chat client")
+    parser.add_argument("--host", default="127.0.0.1", help="server address")
+    parser.add_argument("--port", type=int, default=65432, help="server port")
+    args = parser.parse_args()
+
     key = load_key()
     cipher = Fernet(key)
 
-    # 客户端设置
-    HOST = "127.0.0.1"  # 服务器地址
-    PORT = 65432         # 服务器端口号
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((args.host, args.port))
+    print(f"Connected to server {args.host}:{args.port}")
 
-    # 创建套接字
-    client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    client_socket.connect((HOST, PORT))
-    print(f"Connected to server {HOST}:{PORT}")
+    init(autoreset=True)
 
+    stop_event = threading.Event()
+    pending_reads: set[int] = set()
+    received_messages: dict[int, str] = {}
+    threading.Thread(
+        target=handle_receive,
+        args=(sock, cipher, stop_event, pending_reads, received_messages),
+        daemon=True,
+    ).start()
+    threading.Thread(target=ping_loop, args=(sock, cipher, stop_event), daemon=True).start()
+
+    msg_id = 0
+    sent_messages: dict[int, str] = {}
     try:
-        while True:
-            # 输入消息
-            message = input("Enter message: ")
-            if message.lower() == "exit":
+        while not stop_event.is_set():
+            message = input(Fore.GREEN + "Enter message (/file <path>, /exit): " + Style.RESET_ALL)
+            if message.startswith("/file "):
+                path = Path(message.split(" ", 1)[1]).expanduser()
+                if path.exists():
+                    send_file(sock, cipher, path)
+                else:
+                    print(Fore.RED + "File not found.")
+            elif message.strip() == "/exit":
                 break
-
-            # 加密消息
-            encrypted_message = cipher.encrypt(message.encode())
-
-            # 发送加密消息
-            client_socket.send(encrypted_message)
-
-            # 接收广播的加密消息
-            encrypted_response = client_socket.recv(1024)
-            decrypted_response = cipher.decrypt(encrypted_response).decode()
-            print(f"Received: {decrypted_response}")
-
+            elif message.startswith("/recall "):
+                try:
+                    rid = int(message.split(" ", 1)[1])
+                except ValueError:
+                    print(Fore.RED + "Invalid message ID.")
+                    continue
+                if rid in sent_messages:
+                    send_text(sock, cipher, f"RECALL|{rid}")
+                    sent_messages.pop(rid, None)
+                    pending_reads.discard(rid)
+                    print(Fore.GREEN + f"You recalled message {rid}")
+                else:
+                    print(Fore.RED + "Unknown message ID.")
+            else:
+                msg_id += 1
+                pending_reads.add(msg_id)
+                sent_messages[msg_id] = message
+                send_text(sock, cipher, f"MSG|{msg_id}|{message}")
+                print(Fore.GREEN + f"You({msg_id}): {message} " + Style.DIM + "[sent]")
     except KeyboardInterrupt:
-        print("Disconnected from server.")
+        pass
     finally:
-        client_socket.close()
+        stop_event.set()
+        sock.close()
+
 
 if __name__ == "__main__":
     main()
+

--- a/encrypted_chat/encrypted_chat_client_gui.py
+++ b/encrypted_chat/encrypted_chat_client_gui.py
@@ -1,0 +1,156 @@
+"""Tkinter GUI client for the encrypted chat with read receipts and recall."""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+from pathlib import Path
+from tkinter import Tk, Entry, Button, END, DISABLED, Frame
+from tkinter.scrolledtext import ScrolledText
+
+from cryptography.fernet import Fernet
+
+
+def load_key() -> bytes:
+    key_path = Path("key.key")
+    if not key_path.exists():
+        key_path.write_bytes(Fernet.generate_key())
+    return key_path.read_bytes()
+
+
+def send_encrypted(sock: socket.socket, cipher: Fernet, data: bytes) -> None:
+    encrypted = cipher.encrypt(data)
+    sock.sendall(struct.pack("!I", len(encrypted)))
+    sock.sendall(encrypted)
+
+
+def recv_encrypted(sock: socket.socket, cipher: Fernet) -> bytes:
+    header = sock.recv(4)
+    if len(header) < 4:
+        raise ConnectionError("connection closed")
+    (size,) = struct.unpack("!I", header)
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise ConnectionError("connection closed")
+        data += chunk
+    return cipher.decrypt(data)
+
+
+def send_text(sock: socket.socket, cipher: Fernet, text: str) -> None:
+    send_encrypted(sock, cipher, text.encode())
+
+
+class ChatClientGUI:
+    def __init__(self, master: Tk) -> None:
+        self.master = master
+        self.master.title("Encrypted Chat Client")
+        self.master.geometry("500x400")
+
+        self.text = ScrolledText(master, state=DISABLED, width=60, height=20)
+        self.text.pack(padx=10, pady=10, fill="both", expand=True)
+
+        input_frame = Frame(master)
+        input_frame.pack(fill="x", padx=10, pady=(0, 10))
+
+        self.entry = Entry(input_frame)
+        self.entry.pack(side="left", expand=True, fill="x")
+        self.entry.bind("<Return>", lambda _: self.send_message())
+        self.entry.focus()
+
+        self.send_btn = Button(input_frame, text="Send", command=self.send_message)
+        self.send_btn.pack(side="left", padx=(5, 0))
+
+        self.cipher = Fernet(load_key())
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.connect(("127.0.0.1", 65432))
+
+        self.msg_id = 0
+        self.pending_reads: set[int] = set()
+        self.sent_messages: dict[int, str] = {}
+        self.received_messages: dict[int, str] = {}
+
+        threading.Thread(target=self.receive_messages, daemon=True).start()
+
+    def append_text(self, line: str) -> str:
+        self.text.config(state="normal")
+        index = self.text.index(END)
+        self.text.insert(END, line + "\n")
+        self.text.config(state=DISABLED)
+        return index
+
+    def replace_line(self, index: str, line: str) -> None:
+        end = f"{int(index.split('.')[0]) + 1}.0"
+        self.text.config(state="normal")
+        self.text.delete(index, end)
+        self.text.insert(index, line + "\n")
+        self.text.config(state=DISABLED)
+
+    def send_message(self) -> None:
+        message = self.entry.get()
+        if not message:
+            return
+        if message.startswith("/recall "):
+            try:
+                rid = int(message.split(" ", 1)[1])
+            except ValueError:
+                self.append_text("Invalid message ID")
+                self.entry.delete(0, END)
+                return
+            if rid in self.sent_messages:
+                send_text(self.sock, self.cipher, f"RECALL|{rid}")
+                idx = self.sent_messages.pop(rid)
+                self.replace_line(idx, "[message recalled]")
+                self.append_text(f"You recalled message {rid}")
+            else:
+                self.append_text("Unknown message ID")
+            self.entry.delete(0, END)
+            return
+
+        self.msg_id += 1
+        self.pending_reads.add(self.msg_id)
+        send_text(self.sock, self.cipher, f"MSG|{self.msg_id}|{message}")
+        idx = self.append_text(f"You({self.msg_id}): {message} [sent]")
+        self.sent_messages[self.msg_id] = idx
+        self.entry.delete(0, END)
+
+    def receive_messages(self) -> None:
+        try:
+            while True:
+                data = recv_encrypted(self.sock, self.cipher)
+                text = data.decode(errors="ignore")
+                if text.startswith("READ|"):
+                    msg_id = int(text.split("|", 1)[1])
+                    if msg_id in self.pending_reads:
+                        self.pending_reads.remove(msg_id)
+                        self.append_text(f"Peer read message {msg_id}")
+                elif text.startswith("RECALL|"):
+                    msg_id = int(text.split("|", 1)[1])
+                    idx = self.received_messages.pop(msg_id, None)
+                    if idx is not None:
+                        self.replace_line(idx, "[message recalled]")
+                    else:
+                        self.append_text(f"Peer recalled message {msg_id}")
+                elif text.startswith("MSG|"):
+                    _, msg_id_str, content = text.split("|", 2)
+                    idx = self.append_text(f"Peer({msg_id_str}): {content}")
+                    self.received_messages[int(msg_id_str)] = idx
+                    send_text(self.sock, self.cipher, f"READ|{msg_id_str}")
+                else:
+                    self.append_text(text)
+        except Exception:
+            self.append_text("Connection closed.")
+        finally:
+            self.sock.close()
+
+
+def main() -> None:
+    root = Tk()
+    ChatClientGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cryptography
+colorama

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -1,0 +1,47 @@
+$ErrorActionPreference = 'Stop'
+
+param([string]$PythonVersion = '')
+
+$win = [System.Environment]::OSVersion.Version
+Write-Host "Detected Windows version: $($win.Major).$($win.Minor)"
+
+function Ensure-PackageManager {
+    if (Get-Command winget -ErrorAction SilentlyContinue) { return 'winget' }
+    if (Get-Command choco -ErrorAction SilentlyContinue) { return 'choco' }
+    Write-Host 'No package manager (winget or chocolatey) found. Installing Chocolatey...'
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+    if (Get-Command choco -ErrorAction SilentlyContinue) { return 'choco' }
+    throw 'Failed to install Chocolatey.'
+}
+
+$PackageManager = Ensure-PackageManager
+
+function Ensure-Program($command, $wingetId, $chocoPkg, $version) {
+    if (Get-Command $command -ErrorAction SilentlyContinue) { return }
+    Write-Host "$command not found. Attempting installation..."
+    if ($PackageManager -eq 'winget') {
+        winget install -e --id $wingetId
+    } else {
+        if ($version) {
+            choco install $chocoPkg -y --version $version
+        } else {
+            choco install $chocoPkg -y
+        }
+    }
+}
+
+$wingetId = if ($PythonVersion) {"Python.Python.$PythonVersion"} else {"Python.Python.3"}
+Ensure-Program python $wingetId 'python' $PythonVersion
+
+$pythonCmd = (Get-Command python -ErrorAction SilentlyContinue)
+if (-not $pythonCmd) {
+    $pythonCmd = (Get-Command py -ErrorAction SilentlyContinue)
+    if (-not $pythonCmd) { throw 'Python installation failed. Please install manually.' }
+    $pythonExe = 'py'
+} else {
+    $pythonExe = 'python'
+}
+
+& $pythonExe 'build_windows_installer.py'


### PR DESCRIPTION
## Summary
- show read receipts and color-coded messages in the CLI client for clearer chat status
- document command-line usage in a dedicated guide and reference it from the README
- sync the Tkinter GUI client with the new message protocol
- enable message recall in both CLI and GUI clients and document the new `/recall` command

## Testing
- `python -m py_compile encrypted_chat/*.py build_windows_installer.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ee9c834832b856c4112f142c1ec